### PR TITLE
Change the cask name 

### DIFF
--- a/Casks/devtoolkit.rb
+++ b/Casks/devtoolkit.rb
@@ -21,7 +21,7 @@ cask "devtoolkit" do
 
   url "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/mactoolkit/#{version}-IBM-MQ-DevToolkit-MacOS.pkg",
      verified: "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/"
-  name "devtoolkit"
+  name "mq-dev-toolkit"
   desc "IBM MQ Advanced Toolkit for MacOS"
   homepage "https://github.ibm.com/ibm-messaging/homebrew-ibmmq"
 

--- a/Casks/devtoolkit.rb
+++ b/Casks/devtoolkit.rb
@@ -1,0 +1,149 @@
+=begin
+Copyright 2024 IBM Corp.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=end
+
+
+cask "devtoolkit" do
+  version "9.3.4.0"
+  sha256 "4b928d2ead4973273f0f8e8049a03926cd505373a2fca8830f395d7e8a752bb4"
+
+  url "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/mactoolkit/#{version}-IBM-MQ-DevToolkit-MacOS.pkg",
+     verified: "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/"
+  name "devtoolkit"
+  desc "IBM MQ Advanced Toolkit for MacOS"
+  homepage "https://github.ibm.com/ibm-messaging/homebrew-ibmmq"
+
+  pkg "#{version}-IBM-MQ-DevToolkit-MacOS.pkg"
+
+  uninstall pkgutil: "com.ibm.cloud.mqclient"
+
+  caveats do
+    license "https://ibm.biz/mqdevmacclient"
+    path_environment_variable "/opt/mqm/bin"
+  end
+
+  postflight do
+    def bold (unmodString); "\e[1m#{unmodString}\e[22m" end
+    def underline (unmodString); "\e[4m#{unmodString}\e[24m" end
+    def italic (unmodString); "\e[3m#{unmodString}\e[23m" end
+
+    def showUsage(licenseLocation)
+      puts " "
+      puts underline(bold("PLEASE READ"))
+      puts "Full usage license information can be found in the directory #{licenseLocation}"
+      puts "If you don't accept these license terms please unistall by running"
+      puts italic("brew uninstall ibm-messaging/ibmmq/devtoolkit")
+      puts 
+    end
+
+    def showPostSteps
+      puts
+      puts bold("Post Install") 
+      puts "Add locations of the bin directories /opt/mqm/bin and /opt/mqm/samp/bin" 
+      puts "to the PATH by editing /etc/paths"
+      puts "Set the DYLD_LIBRARY_PATH by entering the following on the command line:" 
+      puts italic("export DYLD_LIBRARY_PATH=/opt/mqm/lib64")
+      puts
+    end
+
+    def get_language 
+      localInfo = `locale`
+      localArray = localInfo.split
+
+      dict = {}
+  
+      localArray.each {
+          |s| 
+          pairs = s.scan /^(.+?)=\"(.+?)\"$/ 
+          pairs.each {
+              |p|
+              dict[p[0]] = p[1]
+          }
+      }
+      
+      dictEntry = nil
+  
+      if (! dict["LANG"].nil?) && (! dict["LANG"].empty?)
+        dictEntry = dict["LANG"]  
+      elsif (! dict["LC_ALL"].nil?) && (! dict["LC_ALL"].empty?)
+        dictEntry = dict["LC_ALL"]
+      else
+        return nill
+      end
+
+      langsplit = dictEntry.scan /^(.+?)_(.+?)$/ 
+      language = ""
+      langsplit.each {
+          |l|
+          language = l[0]
+      }
+
+      return language
+    end    
+
+    def valid_language?(language)
+      validLanguages = ["cs","de","el","en","es","fr",
+                          "in", "it", "ja", "ko", "lt",
+                          "pl","pt","ru","sl","tr",
+                          "zh"]
+      return validLanguages.include? language
+    end
+
+    def determine_language
+      language = get_language
+      if language.nil?
+          puts "Unable to determine language"
+          puts "Defaulting to English"
+          language = "en"
+      end
+  
+      unless valid_language?(language) 
+          puts "invalid language found"
+          language = "en"
+      end
+
+      return language
+    end    
+
+    def build_lic_filename
+      language = determine_language
+      licFile = "LA_" + language    
+      return licFile
+    end    
+
+    def show_license(licenseLocation)
+      licFile = build_lic_filename
+  
+      cmd = "head -7 #{licenseLocation}#{licFile}"
+      system cmd  
+  
+      if "LA_zh" == licFile
+          licFile = "LA_zh_TW"
+          cmd = "head #{licenseLocation}#{licFile}"
+          system(cmd)  
+      end
+      puts " "
+      puts " ...... "
+      puts " "
+    end
+
+    licenseLocation = "/opt/mqm/licenses/"
+
+    show_license(licenseLocation)
+    showUsage(licenseLocation)
+    showPostSteps
+  end
+
+end

--- a/Casks/mqdevtoolkit.rb
+++ b/Casks/mqdevtoolkit.rb
@@ -15,13 +15,13 @@ limitations under the License.
 =end
 
 
-cask "devtoolkit" do
+cask "mqdevtoolkit" do
   version "9.3.4.0"
   sha256 "4b928d2ead4973273f0f8e8049a03926cd505373a2fca8830f395d7e8a752bb4"
 
   url "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/mactoolkit/#{version}-IBM-MQ-DevToolkit-MacOS.pkg",
      verified: "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/"
-  name "mq-dev-toolkit"
+  name "mqdevtoolkit"
   desc "IBM MQ Advanced Toolkit for MacOS"
   homepage "https://github.ibm.com/ibm-messaging/homebrew-ibmmq"
 
@@ -44,7 +44,7 @@ cask "devtoolkit" do
       puts underline(bold("PLEASE READ"))
       puts "Full usage license information can be found in the directory #{licenseLocation}"
       puts "If you don't accept these license terms please unistall by running"
-      puts italic("brew uninstall ibm-messaging/ibmmq/devtoolkit")
+      puts italic("brew uninstall ibm-messaging/ibmmq/mqdevtoolkit")
       puts 
     end
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The eagle eyed of you will notice that there is a second cask `devtoolkit`. We c
 brew uninstall ibm-messaging/ibmmq/devtoolkit
 ```
 
+We will remove the old cask in a later release to allow you to migrate to the new cask.
+
 ## Delete Tap
 To unregister this repository as a tap, run the command
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This repo provides the IBM MQ Toolkit for MacOS as a Brew cask.
 The cask is a simple wrapper for the publically delivered toolkit `.pkg` file.
 
+
 ## Version
 The cask installs the publically available version of the toolkit `9.3.4.0`
 
@@ -19,7 +20,7 @@ https://ibm.biz/mqdevmacclient
 If you accept these license terms, then you may proceed with the install by running the command:
 
 ```
-brew install ibm-messaging/ibmmq/devtoolkit
+brew install ibm-messaging/ibmmq/mqdevtoolkit
 ```
 
 If you do not accept these license terms then do not install. If you do not accept these license terms but have already installed, then uninstall the cask by following the uninstall instructions.   
@@ -27,7 +28,7 @@ If you do not accept these license terms then do not install. If you do not acce
 ## How do I uninstall the cask?
 
 ```
-brew uninstall ibm-messaging/ibmmq/devtoolkit
+brew uninstall ibm-messaging/ibmmq/mqdevtoolkit
 ```
 
 
@@ -41,9 +42,15 @@ brew update
 If an upgrade is available, then you can install it. 
 
 ```
-brew upgrade ibm-messaging/ibmmq/devtoolkit
+brew upgrade ibm-messaging/ibmmq/mqdevtoolkit
 ```
 
+## What's the other cask?
+The eagle eyed of you will notice that there is a second cask `devtoolkit`. We changed the name to `mqdevtoolkit` to make it stand out when you run the command `brew list`. If you have the cask with the old name installed, remove it by running the command
+
+```
+brew uninstall ibm-messaging/ibmmq/devtoolkit
+```
 
 ## Delete Tap
 To unregister this repository as a tap, run the command


### PR DESCRIPTION
The cask name has been modified to allow it to stand out when the command `brew list` is run. The old cask remains to allow users to uninstall the old cask / name and migrate to the new cask / name.