### PR TITLE
Mq container inspector brew formula

### DIFF
--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -17,7 +17,7 @@ limitations under the License.
 class MQContainerInspector < Formula
 
   desc "A collection of tools for interacting with IBM® MQ queue managers running in containers."
-  homepage "https://github.com/ibm-messaging/homebrew-ibmmq"
+  homepage "https://github.com/Apurv-1998/homebrew-ibmmq.git"
 
   # TODO: Confirm -> we will not be creating the release for the mq-container-inspector, hence will not be having the tar-ball and the sha
   # If we are going for a release then we should include url and sha265

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -19,7 +19,7 @@ class Mqcontainerinspector < Formula
   desc "A collection of tools for interacting with IBM® MQ queue managers running in containers."
 
   homepage "https://github.com/ibm-messaging/homebrew-ibmmq.git"
-
+  url "https://github.com/ibm-messaging/mq-container-inspector/archive/refs/heads/main.tar.gz"
   head "https://github.com/ibm-messaging/mq-container-inspector.git", branch: "main"
 
   depends_on "go" => :build

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -25,7 +25,7 @@ class MQContainerInspector < Formula
   # sha256:
 
   # If we are not going for the release we can directly fetch the code from the head
-  head "git@github.ibm.com:mq-cloudpak/mq-container-inspector.git", branch: "main"
+  head "git@github.ibm.com:mq-cloudpak/mq-container-inspector.git", branch: "apurv-mq-container-inspector-brew-formula"
 
   depends_on "go" => :build
 

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -20,7 +20,6 @@ class Mqcontainerinspector < Formula
 
   homepage "https://github.com/ibm-messaging/homebrew-ibmmq.git"
 
-
   head "https://github.com/ibm-messaging/mq-container-inspector.git", branch: "main"
 
   depends_on "go" => :build
@@ -31,6 +30,16 @@ class Mqcontainerinspector < Formula
 
     system "go", "build", *std_go_args(output: bin/"mq-container-inspector", ldflags: ldflags), "."
 
+  end
+
+  def caveats
+    <<~EOS
+      The mq-container-inspector binary has been installed to:
+        #{HOMEBREW_PREFIX}/bin/mq-container-inspector
+
+      You can verify the installation by running:
+        mq-container-inspector --help
+    EOS
   end
 
   test do

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -14,18 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 =end
 
-class MQContainerInspector < Formula
+class Mqcontainerinspector < Formula
 
   desc "A collection of tools for interacting with IBM® MQ queue managers running in containers."
-  homepage "https://github.com/Apurv-1998/homebrew-ibmmq.git"
 
-  # TODO: Confirm -> we will not be creating the release for the mq-container-inspector, hence will not be having the tar-ball and the sha
-  # If we are going for a release then we should include url and sha265
-  # url:
-  # sha256:
+  homepage "https://github.com/ibm-messaging/homebrew-ibmmq.git"
 
-  # If we are not going for the release we can directly fetch the code from the head
-  head "git@github.ibm.com:mq-cloudpak/mq-container-inspector", branch: "apurv-mq-container-inspector-brew-formula"
+
+  head "https://github.com/ibm-messaging/mq-container-inspector.git", branch: "main"
 
   depends_on "go" => :build
 

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 =end
 
-class MQContainerInspector < Formula
+class Mqcontainerinspector < Formula
 
   desc "A collection of tools for interacting with IBM® MQ queue managers running in containers."
   homepage "https://github.com/Apurv-1998/homebrew-ibmmq.git"

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -19,7 +19,9 @@ class Mqcontainerinspector < Formula
   desc "A collection of tools for interacting with IBM® MQ queue managers running in containers."
 
   homepage "https://github.com/ibm-messaging/homebrew-ibmmq.git"
-  url "https://github.com/ibm-messaging/mq-container-inspector/archive/refs/heads/main.tar.gz"
+  url "https://github.com/ibm-messaging/mq-container-inspector/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "7523c2e4053a2efa39fbd4bd2931bad9dc490cbff5d93f5524b667f64dcbbd65"
+  license "Apache-2.0"
   head "https://github.com/ibm-messaging/mq-container-inspector.git", branch: "main"
 
   depends_on "go" => :build

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -18,8 +18,9 @@ class Mqcontainerinspector < Formula
 
   desc "A collection of tools for interacting with IBM® MQ queue managers running in containers."
 
+  version "v1.0.0"
   homepage "https://github.com/ibm-messaging/homebrew-ibmmq.git"
-  url "https://github.com/ibm-messaging/mq-container-inspector/archive/refs/tags/v1.0.0.tar.gz"
+  url "https://github.com/ibm-messaging/mq-container-inspector/archive/refs/tags/#{version}.tar.gz"
   sha256 "7523c2e4053a2efa39fbd4bd2931bad9dc490cbff5d93f5524b667f64dcbbd65"
   license "Apache-2.0"
   head "https://github.com/ibm-messaging/mq-container-inspector.git", branch: "main"

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -25,7 +25,7 @@ class Mqcontainerinspector < Formula
   # sha256:
 
   # If we are not going for the release we can directly fetch the code from the head
-  head "ssh://git@github.ibm.com:mq-cloudpak/mq-container-inspector.git", branch: "main"
+  head "ssh://git@github.ibm.com/mq-cloudpak/mq-container-inspector.git", branch: "main"
 
   depends_on "go" => :build
 

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -1,0 +1,44 @@
+=begin
+Copyright 2025 IBM Corp.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=end
+
+class MQContainerInspector < Formula
+
+  desc "A collection of tools for interacting with IBM® MQ queue managers running in containers."
+  homepage "https://github.com/ibm-messaging/homebrew-ibmmq"
+
+  # TODO: Confirm -> we will not be creating the release for the mq-container-inspector, hence will not be having the tar-ball and the sha
+  # If we are going for a release then we should include url and sha265
+  # url:
+  # sha256:
+
+  # If we are not going for the release we can directly fetch the code from the head
+  head "git@github.ibm.com:mq-cloudpak/mq-container-inspector.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["CGO_ENABLED"] = "0"
+    ldflags = %W[-s -w]
+
+    system "go", "build", *std_go_args(output: bin/"mq-container-inspector", ldflags: ldflags), "."
+
+  end
+
+  test do
+    system "#{bin}/mq-container-inspector", "--help"
+  end
+
+end

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -25,7 +25,7 @@ class MQContainerInspector < Formula
   # sha256:
 
   # If we are not going for the release we can directly fetch the code from the head
-  head "git@github.ibm.com:mq-cloudpak/mq-container-inspector.git", branch: "apurv-mq-container-inspector-brew-formula"
+  head "git@github.ibm.com:mq-cloudpak/mq-container-inspector", branch: "apurv-mq-container-inspector-brew-formula"
 
   depends_on "go" => :build
 

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -25,7 +25,7 @@ class Mqcontainerinspector < Formula
   # sha256:
 
   # If we are not going for the release we can directly fetch the code from the head
-  head "ssh://git@github.ibm.com/mq-cloudpak/mq-container-inspector.git", branch: "main"
+  head "ssh://git@github.ibm.com:mq-cloudpak/mq-container-inspector.git", branch: "main"
 
   depends_on "go" => :build
 

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -17,15 +17,11 @@ limitations under the License.
 class Mqcontainerinspector < Formula
 
   desc "A collection of tools for interacting with IBM® MQ queue managers running in containers."
-  homepage "https://github.com/Apurv-1998/homebrew-ibmmq.git"
 
-  # TODO: Confirm -> we will not be creating the release for the mq-container-inspector, hence will not be having the tar-ball and the sha
-  # If we are going for a release then we should include url and sha265
-  # url:
-  # sha256:
+  homepage "https://github.com/ibm-messaging/homebrew-ibmmq.git"
 
-  # If we are not going for the release we can directly fetch the code from the head
-  head "ssh://git@github.ibm.com/mq-cloudpak/mq-container-inspector.git", branch: "main"
+
+  head "https://github.com/ibm-messaging/mq-container-inspector.git", branch: "main"
 
   depends_on "go" => :build
 

--- a/Formula/mqcontainerinspector.rb
+++ b/Formula/mqcontainerinspector.rb
@@ -25,7 +25,7 @@ class Mqcontainerinspector < Formula
   # sha256:
 
   # If we are not going for the release we can directly fetch the code from the head
-  head "git@github.ibm.com:mq-cloudpak/mq-container-inspector", branch: "apurv-mq-container-inspector-brew-formula"
+  head "ssh://git@github.ibm.com/mq-cloudpak/mq-container-inspector.git", branch: "main"
 
   depends_on "go" => :build
 

--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ To unregister this repository as a tap, run the command
 ```
 brew untap ibm-messaging/ibmmq
 ```
+
+## Formula for mqcontainerinspector
+Installs a MQ container inspector on MacOS
+See. https://github.com/ibm-messaging/mq-container-inspector
+
+### Install MQ container inspector:
+brew install ibm-messaging/ibmmq/mqcontainerinspector
+
+### Verify the Installation:
+mq-container-inspector version


### PR DESCRIPTION
This PR creates the macOS formula to install the mq-container-inspector binary using `brew install`.